### PR TITLE
fix(buffered_writer): synchronize access to write_task

### DIFF
--- a/.github/workflows/crystal.yml
+++ b/.github/workflows/crystal.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Crystal Ameba Linter
-      uses: crystal-ameba/github-action@v0.2.0
+      uses: crystal-ameba/github-action@v0.2.4
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Install dependencies

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: flux
-version: 1.1.0
+version: 1.1.1
 crystal: ~> 0.34
 license: MIT
 
@@ -10,6 +10,7 @@ authors:
 dependencies:
   tasker:
     github: spider-gazelle/tasker
+    version: ~> 1.3
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
Access to `@write_task` was previously unsynchronized.
To achieve this, a reentrant condition was added to the mutex to allow synchronization of the `flush` method.