### PR TITLE
feat(point): use strings as keys

### DIFF
--- a/spec/flux/point_spec.cr
+++ b/spec/flux/point_spec.cr
@@ -5,10 +5,10 @@ describe Flux::Point do
     it "maps fields into a FieldSet" do
       point = Flux::Point.new "foo", a: 1_u64, b: "test", c: 0.0, d: false
       point.fields.should eq({
-        :a => 1_u64,
-        :b => "test",
-        :c => 0.0,
-        :d => false,
+        "a" => 1_u64,
+        "b" => "test",
+        "c" => 0.0,
+        "d" => false,
       })
     end
   end
@@ -17,8 +17,8 @@ describe Flux::Point do
     it "maps fields into a FieldSet, discarding those with nil values" do
       point = Flux::Point.new! "foo", a: 1_u64, b: "test", c: nil, d: nil
       point.fields.should eq({
-        :a => 1_u64,
-        :b => "test",
+        "a" => 1_u64,
+        "b" => "test",
       })
     end
   end
@@ -27,7 +27,7 @@ describe Flux::Point do
     it "allows tagging of points" do
       point = Flux::Point.new "foo", a: 1_u64
       point.tag test: "bar"
-      point.tags.should eq({:test => "bar"})
+      point.tags.should eq({"test" => "bar"})
     end
   end
 

--- a/src/flux/point.cr
+++ b/src/flux/point.cr
@@ -6,11 +6,11 @@ require "./line_protocol"
 # this causes issues elsewhere as you can not have an `Array`, `Channel` etc of
 # a generic type.
 struct Flux::Point
-  alias TagSet = Hash(Symbol | String, String)
+  alias TagSet = Hash(String, String)
 
   alias FieldType = Float64 | Int64 | UInt64 | String | Bool
 
-  alias FieldSet = Hash(Symbol | String, FieldType)
+  alias FieldSet = Hash(String, FieldType)
 
   getter measurement : String
 
@@ -29,7 +29,7 @@ struct Flux::Point
       {% unless type < FieldType %}
         {% raise "invalid type for '#{key}' (#{type}) - fields must be #{FieldType}" %}
       {% end %}
-      fieldset[{{key.symbolize}}] = fields[{{key.symbolize}}]
+      fieldset[{{key.stringify}}] = fields[{{key.stringify}}]
     {% end %}
 
     new measurement, fieldset, timestamp, tags
@@ -44,8 +44,8 @@ struct Flux::Point
       {% unless type < FieldType? %}
         {% raise "invalid type for '#{key}' (#{type}) - fields must be #{FieldType?}" %}
       {% end %}
-      fieldset[{{key.symbolize}}] = fields[{{key.symbolize}}].not_nil! \
-        unless fields[{{key.symbolize}}].nil?
+      fieldset[{{key.stringify}}] = fields[{{key.stringify}}].not_nil! \
+        unless fields[{{key.stringify}}].nil?
     {% end %}
 
     new measurement, fieldset, timestamp, tags
@@ -57,7 +57,7 @@ struct Flux::Point
   # Append or change tags associated with the point.
   def tag(**tags : **T) forall T
     {% for key in T %}
-      self.tags[{{key.symbolize}}] = tags[{{key.symbolize}}]
+      self.tags[{{key.stringify}}] = tags[{{key.stringify}}]
     {% end %}
   end
 

--- a/src/flux/point.cr
+++ b/src/flux/point.cr
@@ -6,11 +6,11 @@ require "./line_protocol"
 # this causes issues elsewhere as you can not have an `Array`, `Channel` etc of
 # a generic type.
 struct Flux::Point
-  alias TagSet = Hash(Symbol, String)
+  alias TagSet = Hash(Symbol | String, String)
 
   alias FieldType = Float64 | Int64 | UInt64 | String | Bool
 
-  alias FieldSet = Hash(Symbol, FieldType)
+  alias FieldSet = Hash(Symbol | String, FieldType)
 
   getter measurement : String
 


### PR DESCRIPTION
so we can modify the point after initialization with runtime keys

working on the slightly modified version of the PlaceOS statistics collection and want to use the status name as the field name as currently we're using `value` but this complicates querying and is not best practice.
Basically field data types should not really change: https://docs.influxdata.com/influxdb/v1.8/troubleshooting/frequently-asked-questions/#can-i-change-a-field-s-data-type

We can safely do this as can quote field names: https://docs.influxdata.com/influxdb/v1.8/query_language/spec/#identifiers
hence should work with any weird status keys implemented by drivers
