### PR TITLE
HTTP::Params deprecated in favor of URI::Params

### DIFF
--- a/src/flux/client.cr
+++ b/src/flux/client.cr
@@ -9,7 +9,7 @@ require "./query_result"
 class Flux::Client
   Log = ::Log.for(self)
   {% begin %}
-  	alias Params = {{HTTP::Params.resolve? ? HTTP : URI}}::Params
+    alias Params = {{HTTP::Params.resolve? ? HTTP : URI}}::Params
   {% end %}
 
   # Creates a new InfluxDB client for the instance running at the specified

--- a/src/flux/client.cr
+++ b/src/flux/client.cr
@@ -8,6 +8,9 @@ require "./query_result"
 
 class Flux::Client
   Log = ::Log.for(self)
+  {% begin %}
+  	alias Params = {{HTTP::Params.resolve? ? HTTP : URI}}::Params
+  {% end %}
 
   # Creates a new InfluxDB client for the instance running at the specified
   # *url*.
@@ -62,7 +65,7 @@ class Flux::Client
   # Write a set of data points to *bucket* on the connected instance.
   # TODO: check influx support for chunked transfer encoding
   private def write_internal(bucket : String, data : IO)
-    params = HTTP::Params.build do |param|
+    params = Params.build do |param|
       param.add "bucket", bucket
     end
 

--- a/src/flux/client.cr
+++ b/src/flux/client.cr
@@ -9,7 +9,7 @@ require "./query_result"
 class Flux::Client
   Log = ::Log.for(self)
   {% begin %}
-    alias Params = {{HTTP::Params.resolve? ? HTTP : URI}}::Params
+    private alias Params = {{HTTP::Params.resolve? ? HTTP : URI}}::Params
   {% end %}
 
   # Creates a new InfluxDB client for the instance running at the specified


### PR DESCRIPTION
This change should allow for both `HTTP::Params` and `URI::Params`, so this can continue to work on Crystal 0.35 as well as whenever the deprecated `HTTP::Params` is removed.