### PR TITLE
Allow for reusing TCP connections

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,6 +11,9 @@ dependencies:
   tasker:
     github: spider-gazelle/tasker
     version: ~> 1.3
+  db:
+    github: crystal-lang/crystal-db
+    version: ~> 0.10.0
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
This eliminates TCP handshakes, TCP slow start, and potentially TLS negotiation for subsequent requests.

The `max_idle_pool_size` is just a starter value. I normally parse it from the URL the way [the `crystal-lang/crystal-db` shard does](https://github.com/crystal-lang/crystal-db/blob/eaddae7d71d52536453ea2d94777854f1b057f83/src/db/driver.cr#L31-L40), but I think it makes sense to discuss that as a feature first.