### PR TITLE
refactor: use FLUX_URI instead of FLUX_HOST

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ with appriopriate setters.
 
 ```crystal
 Flux.configure do |settings|
-  settings.host    = ENV["INFLUX_HOST"]? || abort "INFLUX_HOST env var not set"
+  settings.uri     = ENV["INFLUX_URI"]? || abort "INFLUX_URI env var not set"
   settings.api_key = ENV["INFLUX_API_KEY"]? || abort "INFLUX_API_KEY env var not set"
   settings.org     = ENV["INFLUX_ORG"]? || "vandelay-industries"
   settings.bucket  = ENV["INFLUX_BUCKET"]? || "latex-sales"

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: flux
-version: 1.1.3
+version: 2.0.0
 crystal: ~> 0.34
 license: MIT
 

--- a/spec/flux_spec.cr
+++ b/spec/flux_spec.cr
@@ -26,7 +26,7 @@ describe Flux do
     context "following global config" do
       it "writes single points" do
         Flux.configure do |settings|
-          settings.host = "http://example.com"
+          settings.uri = "http://example.com"
           settings.api_key = "abc"
           settings.org = "foo"
           settings.bucket = "test"

--- a/src/flux.cr
+++ b/src/flux.cr
@@ -5,7 +5,7 @@ module Flux
   VERSION = `shards version`
 
   class Options
-    property host : String? = nil
+    property uri : String? = nil
     property api_key : String? = nil
     property org : String? = nil
     property bucket : String? = nil
@@ -25,11 +25,10 @@ module Flux
     @@client = nil
     @@writer = nil
 
-    config = Options.new
-    yield config
+    yield (config = Options.new)
 
     @@client = Flux::Client.new(
-      host: config.host.not_nil!,
+      uri: config.uri.not_nil!,
       token: config.api_key.not_nil!,
       org: config.org.not_nil!,
     )
@@ -41,7 +40,7 @@ module Flux
       flush_delay: config.flush_delay
     )
   rescue NilAssertionError
-    raise "Incomplete configuration - host, token, org and bucket must be specified"
+    raise "Incomplete configuration - uri, token, org and bucket must be specified"
   end
 
   private def self.client

--- a/src/flux/client.cr
+++ b/src/flux/client.cr
@@ -10,13 +10,14 @@ class Flux::Client
   Log = ::Log.for(self)
 
   # Creates a new InfluxDB client for the instance running at the specified
-  # *url*.
+  # *uri*.
   #
   # *token* must be a valid API token on the instance that provides sufficient
   # privaleges for the buckets being interact with. Similarly *org* must match
   # the appropriate *org* name these buckets sit under.
-  def initialize(host, @token : String, @org : String)
-    @uri = URI.parse host
+  def initialize(uri : String, @token : String, @org : String)
+    @uri = URI.parse uri
+    raise "Malformed URI" unless {@uri.host, @uri.scheme}.all? &.presence
   end
 
   # Creates a new `HTTP::Client` for executing a request.


### PR DESCRIPTION
`FLUX_HOST` implies hostname while it accepts a uri, hence `FLUX_URI` was introduced.
This PR _could_ retain `FLUX_HOST` and construct a URI if desired.