### PR TITLE
feat: make public Flux::QueryResult::Table(T) private getter records

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -10,7 +10,7 @@ authors:
 dependencies:
   tasker:
     github: spider-gazelle/tasker
-    version: ~> 1.3
+    version: ~> 2
 
 development_dependencies:
   ameba:

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: flux
-version: 2.0.0
+version: 2.1.0
 crystal: ~> 0.34
 license: MIT
 

--- a/src/flux/query_result/table.cr
+++ b/src/flux/query_result/table.cr
@@ -5,7 +5,7 @@ struct Flux::QueryResult::Table(T)
 
   getter columns : Array(Column)
 
-  private getter records = [] of T
+  getter records = [] of T
 
   def initialize(@columns)
   end


### PR DESCRIPTION
- Make `private getter records` from `Flux::QueryResult::Table(T)` `public`
- Bump tasker to v2