### PR TITLE
build(shard.yml): bump tasker to v2

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: flux
-version: 2.0.0
+version: 2.0.1
 crystal: ~> 0.34
 license: MIT
 
@@ -10,7 +10,7 @@ authors:
 dependencies:
   tasker:
     github: spider-gazelle/tasker
-    version: ~> 1.3
+    version: ~> 2
 
 development_dependencies:
   ameba:


### PR DESCRIPTION
Following up on https://github.com/place-labs/flux/pull/9#issuecomment-802359199