### PR TITLE
chore(annotated csv): fix when running on crystal nightly

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,6 +1,6 @@
 name: flux
-version: 3.0.0
-crystal: ">=0.36.0, < 2.0.0"
+version: 3.0.1
+crystal: ">=0.36.0"
 license: MIT
 
 authors:

--- a/spec/flux/annotated_csv_spec.cr
+++ b/spec/flux/annotated_csv_spec.cr
@@ -15,7 +15,7 @@ describe Flux::AnnotatedCSV do
     CSV
   csv = Flux::AnnotatedCSV.new io, headers: true
 
-  it "provides extractions from the base CSV class" do
+  it "provides extractions from the base CSV class", focus: true do
     csv.headers.should eq(["", "result", "table", "_start", "_stop", "_time",
                            "region", "host", "_value"])
   end

--- a/spec/flux/annotated_csv_spec.cr
+++ b/spec/flux/annotated_csv_spec.cr
@@ -15,7 +15,7 @@ describe Flux::AnnotatedCSV do
     CSV
   csv = Flux::AnnotatedCSV.new io, headers: true
 
-  it "provides extractions from the base CSV class", focus: true do
+  it "provides extractions from the base CSV class" do
     csv.headers.should eq(["", "result", "table", "_start", "_stop", "_time",
                            "region", "host", "_value"])
   end

--- a/src/flux/annotated_csv.cr
+++ b/src/flux/annotated_csv.cr
@@ -22,7 +22,14 @@ class Flux::AnnotatedCSV < CSV
   def initialize(string_or_io : String | IO, headers = false, @strip = false, separator : Char = DEFAULT_SEPARATOR, quote_char : Char = DEFAULT_QUOTE_CHAR)
     @parser = Parser.new(string_or_io, separator, quote_char)
 
-    while @parser.peek == ANNOTATION_CHAR && (cols = @parser.next_row)
+    loop do
+      peeked_char = @parser.peek
+      puts "peeking: #{peeked_char}"
+      break unless peeked_char == ANNOTATION_CHAR
+      cols = @parser.next_row
+      puts "found cols: #{cols}"
+      break unless cols
+
       type = cols[0].lchop ANNOTATION_CHAR
       if annotations = @annotations
         annotations.zip(cols) { |col, value| col[type] = value }

--- a/src/flux/annotated_csv.cr
+++ b/src/flux/annotated_csv.cr
@@ -23,7 +23,7 @@ class Flux::AnnotatedCSV < CSV
     @parser = Parser.new(string_or_io, separator, quote_char)
     cols = @parser.next_row || ([] of String)
     count = 0
-    while cols[0]?.try(&.[]?(0)) == ANNOTATION_CHAR
+    while cols.first?.try(&.first?) == ANNOTATION_CHAR
       count += 1
       type = cols[0].lchop ANNOTATION_CHAR
       if annotations = @annotations

--- a/src/flux/annotated_csv.cr
+++ b/src/flux/annotated_csv.cr
@@ -23,7 +23,7 @@ class Flux::AnnotatedCSV < CSV
     @parser = Parser.new(string_or_io, separator, quote_char)
     cols = @parser.next_row || ([] of String)
     count = 0
-    while cols.first?.try(&.first?) == ANNOTATION_CHAR
+    while cols.first?.try &.starts_with?(ANNOTATION_CHAR)
       count += 1
       type = cols[0].lchop ANNOTATION_CHAR
       if annotations = @annotations

--- a/src/flux/annotated_csv.cr
+++ b/src/flux/annotated_csv.cr
@@ -23,7 +23,7 @@ class Flux::AnnotatedCSV < CSV
     @parser = Parser.new(string_or_io, separator, quote_char)
     cols = @parser.next_row || ([] of String)
     count = 0
-    while cols[0][0]? == ANNOTATION_CHAR
+    while cols[0]?.try(&.[]?(0)) == ANNOTATION_CHAR
       count += 1
       type = cols[0].lchop ANNOTATION_CHAR
       if annotations = @annotations

--- a/src/flux/annotated_csv.cr
+++ b/src/flux/annotated_csv.cr
@@ -41,6 +41,7 @@ class Flux::AnnotatedCSV < CSV
         indices[header] ||= index
       end
     else
+      # we are one row ahead of where we should be so need to rewind
       @parser.rewind
       count.times { @parser.next_row }
     end
@@ -57,17 +58,5 @@ class Flux::AnnotatedCSV < CSV
   def annotations(header : String)
     index = indices[header]
     annotations[index]
-  end
-end
-
-class CSV::Parser
-  protected def peek
-    @lexer.peek
-  end
-end
-
-abstract class CSV::Lexer
-  protected def peek
-    current_char
   end
 end


### PR DESCRIPTION
issue introduced with this commit: https://github.com/crystal-lang/crystal/pull/11174
so the peek fails as after the first line as instead of `#` it returns the newline char
